### PR TITLE
Sort mækelist alphabetically

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,8 @@
 ---
 layout: default
 ---
-{% for m in site.m limit:45 %}
+{% assign sorted_m = site.m | sort: "name" %}
+{% for m in sorted_m limit:45 %}
     <a class="maerke-box" href="{{ site.baseurl }}{{ m.url }}" style="background-image: url('{{ site.baseurl }}/img/{{ m.image }}');">
         <h1>{{ m.name }}</h1>
     </a>

--- a/m.json
+++ b/m.json
@@ -1,6 +1,7 @@
 ---
 ---
-{ "m": [{% for m in site.m %}
+{% assign sorted_m = site.m | sort: "name" %}
+{ "m": [{% for m in sorted_m %}
   {
     "name": {{ m.name | jsonify }},
     "description": {{ m.description | jsonify }},


### PR DESCRIPTION
Before, it was sorted alphabetically by id. Changed to sort alphabetically by name (very better good)