### PR TITLE
Png favicon alt

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,6 +15,7 @@
         <meta property="og:description" content="{{ page_description }}">
         <meta property="og:locale" content="da_DK">
 
+        <link rel="shortcut icon" type="image/png" href="{{ site.baseurl }}/img/favicon.png">
         <link rel="shortcut icon" type="image/svg+xml" href="{{ site.baseurl }}/img/logo.svg">
         <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/css/style.css">
         <script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,7 @@
         <meta property="og:description" content="{{ page_description }}">
         <meta property="og:locale" content="da_DK">
 
-        <link rel="shortcut icon" type="image/png" href="{{ site.baseurl }}/img/logo.svg">
+        <link rel="shortcut icon" type="image/svg+xml" href="{{ site.baseurl }}/img/logo.svg">
         <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/css/style.css">
         <script>
             function debounced(fun, timeout) {


### PR DESCRIPTION
Using the old PNG logo as a favicon is desireable in some situations. My phone did not show the SVG image properly as a favicon, for example.