### PR TITLE
Replace all inline-html-things with nothing at all in names when sear…

### DIFF
--- a/js/raw-search.js
+++ b/js/raw-search.js
@@ -27,7 +27,7 @@ rawSearch = function(recovery) {
 
 function matchesMaerke(maerke, value) {
     var valueRegex = new RegExp(value, "i");
-    if(maerke.name.match(valueRegex)) {
+    if(maerke.name.replace(/&.+;/, '').match(valueRegex)) {
         return true;
     }
     for(var i = 0; i < maerke.tags.length; i++) {


### PR DESCRIPTION
…chign for them

This means that soft hyphens become empty strings, eg. hoejde&#123;fantaster -> hoejdefantaster