### PR TITLE
Search multi word and tags

### DIFF
--- a/_layouts/maerke.html
+++ b/_layouts/maerke.html
@@ -9,7 +9,7 @@ layout: default
   <h1>{{ page.name }}</h1>
   <div class="tags">
       {% for tag in page.tags %}
-          <a class="tag" href="{{ site.baseurl }}/?search={{ tag }}">{{ tag }}</a>
+          <a class="tag" href="{{ site.baseurl }}/?search=tag:{{ tag }}">{{ tag }}</a>
       {% endfor %}
   </div>
   <p>

--- a/js/raw-search.js
+++ b/js/raw-search.js
@@ -38,6 +38,13 @@ function allTermsMatchMaerke(maerke, terms) {
 }
 
 function matchesMaerke(maerke, term) {
+    if(term.indexOf("tag:") == 0) {
+        var termTag = term.substring(4);
+        return maerke.tags.some(function(maerkeTag) {
+            return maerkeTag.match(new RegExp("^" + termTag + "$", "i"));
+        });
+    }
+
     var valueRegex = new RegExp(term, "i");
     if(maerke.name.replace(/&.+;/, '').match(valueRegex)) {
         return true;

--- a/js/raw-search.js
+++ b/js/raw-search.js
@@ -124,7 +124,7 @@ var tags = document.querySelectorAll("a.tag");
 Array.prototype.forEach.call(tags, function(tag) {
     tag.addEventListener("click", function(e) {
         e.preventDefault();
-        searchBar.value = tag.innerHTML;
+        searchBar.value = "tag:" + tag.innerHTML;
         searchBar.focus();
         search();
         return true;

--- a/js/raw-search.js
+++ b/js/raw-search.js
@@ -4,11 +4,13 @@ var titleTag = document.head.querySelector("title");
 
 rawSearch = function(recovery) {
     var value = searchBar.value;
-    console.log("searching", value);
+    var terms = getTermsFromSearchString(value);
+
+    console.log("searching", terms);
 
     var matches = [];
     searchData.forEach(function(maerke) {
-        if(matchesMaerke(maerke, value)) {
+        if(allTermsMatchMaerke(maerke, terms)) {
             matches.push(maerke);
         }
     });
@@ -25,8 +27,18 @@ rawSearch = function(recovery) {
     renderMatches(matches);
 }
 
-function matchesMaerke(maerke, value) {
-    var valueRegex = new RegExp(value, "i");
+function getTermsFromSearchString(str) {
+    return str.replace(/\s+/, ' ').split(' ');
+}
+
+function allTermsMatchMaerke(maerke, terms) {
+    return terms.every(function(term) {
+        return matchesMaerke(maerke, term);
+    });
+}
+
+function matchesMaerke(maerke, term) {
+    var valueRegex = new RegExp(term, "i");
     if(maerke.name.replace(/&.+;/, '').match(valueRegex)) {
         return true;
     }


### PR DESCRIPTION
This adds support for searching things like "førstehjælp uofficielt" and "førstehjælp tag:dds".

Also clicking a tag now searches "tag:uofficielt" instead of just "uofficielt", so we only match on exact tags.