### PR TITLE
Age search

### DIFF
--- a/_m/dgp-aerlighed.html
+++ b/_m/dgp-aerlighed.html
@@ -15,6 +15,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 5-16
 image: dgp-aerlighed.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/engagementsmaerker/tro-og-etik/aerlighed/
+buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/engagementsmaerker/tro-og-etik/aerlighed/
 ---

--- a/_m/dgp-baalmager.html
+++ b/_m/dgp-baalmager.html
@@ -11,6 +11,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 5-9
 image: dgp-baalmager.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/udfordringsmaerker-for-spirer-groensmutter/den-seje/baalmager/
+buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spirer-groensmutter/den-seje/baalmager/
 ---

--- a/_m/dgp-bangebuksen.html
+++ b/_m/dgp-bangebuksen.html
@@ -11,6 +11,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 5-9
 image: dgp-bangebuksen.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/udfordringsmaerker-for-spirer-groensmutter/den-modige/bangebuksen/
+buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spirer-groensmutter/den-modige/bangebuksen/
 ---

--- a/_m/dgp-boelgebetvingere.html
+++ b/_m/dgp-boelgebetvingere.html
@@ -12,6 +12,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 9-16
 image: dgp-boelgebetvingere.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/udfordringsmaerker-for-spejdere-seniorspejdere/overleveren/boelgebetvingere/
+buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spejdere-seniorspejdere/overleveren/boelgebetvingere/
 ---

--- a/_m/dgp-de-seje-kvinders-fodspor.html
+++ b/_m/dgp-de-seje-kvinders-fodspor.html
@@ -12,6 +12,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 9-16
 image: dgp-de-seje-kvinders-fodspor.jpg
 buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spejdere-seniorspejdere/stifinderen/de-seje-kvinders-fodspor/
 ---

--- a/_m/dgp-dolkemaerket.html
+++ b/_m/dgp-dolkemaerket.html
@@ -16,6 +16,7 @@ tags:
 - duelighed
 - dolk
 - kniv
+age: 5-9
 image: dgp-dolkemaerket.jpg
 buylink: http://pigespejder.dk/forside/for-pigespejdere/aktiviteter/?user_aktbase_pi1[search]=find%20aktiviteter&user_aktbase_pi1[actid]=304&user_aktbase_pi1[pointer]=11
 ---

--- a/_m/dgp-fartstriber.html
+++ b/_m/dgp-fartstriber.html
@@ -11,6 +11,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 5-9
 image: dgp-fartstriber.jpg
 buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spirer-groensmutter/den-nysgerrige/fartstriber/
 ---

--- a/_m/dgp-graenseboksere.html
+++ b/_m/dgp-graenseboksere.html
@@ -11,6 +11,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 5-9
 image: dgp-graenseboksere.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/udfordringsmaerker-for-spirer-groensmutter/den-modige/graenseboksere/
+buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spirer-groensmutter/den-modige/graenseboksere/
 ---

--- a/_m/dgp-graensebrydere.html
+++ b/_m/dgp-graensebrydere.html
@@ -12,6 +12,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 9-16
 image: dgp-graensebrydere.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/udfordringsmaerker-for-spejdere-seniorspejdere/vovehalsen/graensebrydere/
+buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spejdere-seniorspejdere/vovehalsen/graensebrydere/
 ---

--- a/_m/dgp-heltetoeser.html
+++ b/_m/dgp-heltetoeser.html
@@ -11,6 +11,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 5-9
 image: dgp-heltetoeser.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/udfordringsmaerker-for-spirer-groensmutter/den-modige/heltetoeser/
+buylink: http://pigespejder.dk/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spirer-groensmutter/den-modige/heltetoeser/
 ---

--- a/_m/dgp-hikegak.html
+++ b/_m/dgp-hikegak.html
@@ -13,6 +13,7 @@ tags:
 - pigespejder
 - forløb
 - hejk
+age: 9-16
 image: dgp-hikegak.jpg
 buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spejdere-seniorspejdere/stifinderen/hikegak/
 ---

--- a/_m/dgp-hikegik.html
+++ b/_m/dgp-hikegik.html
@@ -12,6 +12,7 @@ tags:
 - pigespejder
 - forløb
 - hejk
+age: 5-9
 image: dgp-hikegik.png
 buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spirer-groensmutter/den-nysgerrige/hikegik/
 ---

--- a/_m/dgp-hjem.html
+++ b/_m/dgp-hjem.html
@@ -12,6 +12,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 5-16
 image: dgp-hjem.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/engagementsmaerker/verdensborger/hjem/
+buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/engagementsmaerker/verdensborger/hjem/
 ---

--- a/_m/dgp-hoejdefantaster.html
+++ b/_m/dgp-hoejdefantaster.html
@@ -12,6 +12,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 9-16
 image: dgp-hoejdefantaster.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/udfordringsmaerker-for-spejdere-seniorspejdere/overleveren/hoejdefantaster/
+buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spejdere-seniorspejdere/overleveren/hoejdefantaster/
 ---

--- a/_m/dgp-ildmagere.html
+++ b/_m/dgp-ildmagere.html
@@ -12,6 +12,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 9-16
 image: dgp-ildmagere.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/udfordringsmaerker-for-spejdere-seniorspejdere/vovehalsen/ildmagere/
+buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spejdere-seniorspejdere/vovehalsen/ildmagere/
 ---

--- a/_m/dgp-kaerlighed.html
+++ b/_m/dgp-kaerlighed.html
@@ -14,6 +14,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 5-16
 image: dgp-kaerlighed.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/engagementsmaerker/pige/kaerlighed/
+buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/engagementsmaerker/pige/kaerlighed/
 ---

--- a/_m/dgp-klatretoeser.html
+++ b/_m/dgp-klatretoeser.html
@@ -12,6 +12,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 9-16
 image: dgp-klatretoeser.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/udfordringsmaerker-for-spejdere-seniorspejdere/vovehalsen/klatretoeser/
+buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spejdere-seniorspejdere/vovehalsen/klatretoeser/
 ---

--- a/_m/dgp-loebelus.html
+++ b/_m/dgp-loebelus.html
@@ -11,6 +11,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 5-9
 image: dgp-loebelus.jpg
 buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spirer-groensmutter/den-nysgerrige/loebelus/
 ---

--- a/_m/dgp-loeboratorium.html
+++ b/_m/dgp-loeboratorium.html
@@ -12,6 +12,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 9-16
 image: dgp-loeboratorium.jpg
 buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spejdere-seniorspejdere/stifinderen/loeboratorium/
 ---

--- a/_m/dgp-mig-og-mine.html
+++ b/_m/dgp-mig-og-mine.html
@@ -12,6 +12,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 5-16
 image: dgp-mig-og-mine.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/engagementsmaerker/verdensborger/mig-og-mine-10-mio-veninder/
+buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/engagementsmaerker/verdensborger/mig-og-mine-10-mio-veninder/
 ---

--- a/_m/dgp-modig.html
+++ b/_m/dgp-modig.html
@@ -11,6 +11,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 5-9
 image: dgp-modig.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/udfordringsmaerker-for-spirer-groensmutter/den-modige/modig/
+buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spirer-groensmutter/den-modige/modig/
 ---

--- a/_m/dgp-moerkesjov.html
+++ b/_m/dgp-moerkesjov.html
@@ -11,6 +11,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 5-9
 image: dgp-moerkesjov.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/udfordringsmaerker-for-spirer-groensmutter/den-modige/moerkesjov/
+buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spirer-groensmutter/den-modige/moerkesjov/
 ---

--- a/_m/dgp-mulm-og-moerke.html
+++ b/_m/dgp-mulm-og-moerke.html
@@ -12,6 +12,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 9-16
 image: dgp-mulm-og-moerke.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/udfordringsmaerker-for-spejdere-seniorspejdere/vovehalsen/mulm-og-moerke/
+buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spejdere-seniorspejdere/vovehalsen/mulm-og-moerke/
 ---

--- a/_m/dgp-omsorg.html
+++ b/_m/dgp-omsorg.html
@@ -15,6 +15,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 5-16
 image: dgp-omsorg.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/engagementsmaerker/tro-og-etik/omsorg/
+buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/engagementsmaerker/tro-og-etik/omsorg/
 ---

--- a/_m/dgp-opdagelsesrejsende.html
+++ b/_m/dgp-opdagelsesrejsende.html
@@ -12,6 +12,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 9-16
 image: dgp-opdagelsesrejsende.jpg
 buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spejdere-seniorspejdere/stifinderen/opdagelsesrejsende/
 ---

--- a/_m/dgp-paa-farten.html
+++ b/_m/dgp-paa-farten.html
@@ -12,6 +12,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 9-16
 image: dgp-paa-farten.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/udfordringsmaerker-for-spejdere-seniorspejdere/vovehalsen/paa-farten/
+buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spejdere-seniorspejdere/vovehalsen/paa-farten/
 ---

--- a/_m/dgp-redok.html
+++ b/_m/dgp-redok.html
@@ -12,6 +12,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 9-16
 image: dgp-redok.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/udfordringsmaerker-for-spejdere-seniorspejdere/overleveren/redok/
+buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spejdere-seniorspejdere/overleveren/redok/
 ---

--- a/_m/dgp-skaebnejaeger.html
+++ b/_m/dgp-skaebnejaeger.html
@@ -11,6 +11,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 5-9
 image: dgp-skaebnejaeger.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/udfordringsmaerker-for-spirer-groensmutter/den-seje/skaebnejaeger/
+buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spirer-groensmutter/den-seje/skaebnejaeger/
 ---

--- a/_m/dgp-skaebnespil.html
+++ b/_m/dgp-skaebnespil.html
@@ -12,6 +12,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 9-16
 image: dgp-skaebnespil.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/udfordringsmaerker-for-spejdere-seniorspejdere/overleveren/skaebnespil/
+buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spejdere-seniorspejdere/overleveren/skaebnespil/
 ---

--- a/_m/dgp-skovtrolde.html
+++ b/_m/dgp-skovtrolde.html
@@ -11,6 +11,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 5-9
 image: dgp-loebelus.jpg
 buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spirer-groensmutter/den-nysgerrige/skovtrolde/
 ---

--- a/_m/dgp-sporhunde.html
+++ b/_m/dgp-sporhunde.html
@@ -11,6 +11,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 5-9
 image: dgp-sporhunde.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/udfordringsmaerker-for-spirer-groensmutter/den-seje/sporhunde/
+buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spirer-groensmutter/den-seje/sporhunde/
 ---

--- a/_m/dgp-tegnryttere.html
+++ b/_m/dgp-tegnryttere.html
@@ -11,6 +11,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 5-9
 image: dgp-tegnryttere.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/udfordringsmaerker-for-spirer-groensmutter/den-seje/tegnryttere/
+buylink: http://pigespejder.dk/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spirer-groensmutter/den-seje/tegnryttere/
 ---

--- a/_m/dgp-udforskere.html
+++ b/_m/dgp-udforskere.html
@@ -11,6 +11,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 5-9
 image: dgp-udforskere.jpg
 buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spirer-groensmutter/den-nysgerrige/udforskere/
 ---

--- a/_m/dgp-urbanister.html
+++ b/_m/dgp-urbanister.html
@@ -12,6 +12,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 9-16
 image: dgp-urbanister.jpg
 buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spejdere-seniorspejdere/stifinderen/urbanister/
 ---

--- a/_m/dgp-vandplaskere.html
+++ b/_m/dgp-vandplaskere.html
@@ -11,6 +11,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 5-9
 image: dgp-vandplaskere.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/udfordringsmaerker-for-spirer-groensmutter/den-seje/vandplaskere/
+buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spirer-groensmutter/den-seje/vandplaskere/
 ---

--- a/_m/dgp-vildmarkspiger.html
+++ b/_m/dgp-vildmarkspiger.html
@@ -12,6 +12,7 @@ tags:
 - DGP
 - pigespejder
 - forløb
+age: 9-16
 image: dgp-vildmarkspiger.jpg
-buylink: http://pigespejder.dk/forside/for-pigespejdere/programstof/udfordringsmaerker-for-spejdere-seniorspejdere/overleveren/vildmarkspiger/
+buylink: http://pigespejder.dk/de/forside/for-pigespejdere/aktivitetsmateriale/udfordringsmaerker-for-spejdere-seniorspejdere/overleveren/vildmarkspiger/
 ---

--- a/js/raw-search.js
+++ b/js/raw-search.js
@@ -45,6 +45,22 @@ function matchesMaerke(maerke, term) {
         });
     }
 
+    if(term.indexOf("alder:") == 0) {
+        var termAge = parseInt(term.substring(6));
+        if(isNaN(termAge)) {
+            console.warn("User input in 'alder' invalid (should be number, is NaN)", term);
+            return false;
+        }
+        if(maerke.age == "*") {
+            return true;
+        }
+        if(maerke.age.indexOf("-") == -1) {
+            return termAge == maerke.age;
+        }
+        var maerkeRange = maerke.age.split("-");
+        return termAge >= maerkeRange[0] && termAge <= maerkeRange[1];
+    }
+
     var valueRegex = new RegExp(term, "i");
     if(maerke.name.replace(/&.+;/, '').match(valueRegex)) {
         return true;

--- a/m.json
+++ b/m.json
@@ -10,6 +10,7 @@
     "tags": [{% for tag in m.tags %}
       "{{ tag }}"{% unless forloop.last %},{% endunless %}{% endfor %}
     ],
+    "age": "{% if m.age %}{{ m.age }}{% else %}*{% endif %}",
     "url": {{ m.url | jsonify }}
   }{% unless forloop.last %},{% endunless %}{% endfor %}
 ] }

--- a/m.summary.json
+++ b/m.summary.json
@@ -1,4 +1,4 @@
 ---
 ---
 {% assign sorted_m = site.m | sort: "name" %}
-{ "m": [{% for m in sorted_m %} { "name": {{ m.name | jsonify }}, "image": {{ m.image | jsonify }}, "tags": [{% for tag in m.tags %} "{{ tag }}"{% unless forloop.last %},{% endunless %}{% endfor %} ], "url": {{ m.url | jsonify }} }{% unless forloop.last %},{% endunless %}{% endfor %} ] }
+{ "m": [{% for m in sorted_m %} { "name": {{ m.name | jsonify }}, "image": {{ m.image | jsonify }}, "tags": [{% for tag in m.tags %} "{{ tag }}"{% unless forloop.last %},{% endunless %}{% endfor %}], "url": {{ m.url | jsonify }} }{% unless forloop.last %},{% endunless %}{% endfor %} ] }

--- a/m.summary.json
+++ b/m.summary.json
@@ -1,4 +1,4 @@
 ---
 ---
 {% assign sorted_m = site.m | sort: "name" %}
-{ "m": [{% for m in sorted_m %} { "name": {{ m.name | jsonify }}, "image": {{ m.image | jsonify }}, "tags": [{% for tag in m.tags %} "{{ tag }}"{% unless forloop.last %},{% endunless %}{% endfor %}], "url": {{ m.url | jsonify }} }{% unless forloop.last %},{% endunless %}{% endfor %} ] }
+{ "m": [{% for m in sorted_m %} { "name": {{ m.name | jsonify }}, "image": {{ m.image | jsonify }}, "tags": [{% for tag in m.tags %} "{{ tag }}"{% unless forloop.last %},{% endunless %}{% endfor %}], "age": {% if m.age %}"{{ m.age }}"{% else %}"*"{% endif %}, "url": {{ m.url | jsonify }} }{% unless forloop.last %},{% endunless %}{% endfor %} ] }


### PR DESCRIPTION
Depends on #66 (**merge #66 first!**)

This adds age search. Search by using the "alder:" prefix.

In this PR it works with girl scout badges. Search like this to get DGP badges appropriate for 14-year-olds: `age:14 tag:pigespejder`.

All badges that do not have an `age` set will default to `*` (all-ages).