### PR TITLE
Preorder 36 timer badge

### DIFF
--- a/_layouts/maerke.html
+++ b/_layouts/maerke.html
@@ -63,11 +63,17 @@ layout: default
       {% if page.price %}
       <div class="purchase-form">
         <div class="btn-container">
-          <a class="btn buylink" id="order-expand-btn">Køb fra Mærkelex</a>
+          <a class="btn buylink" id="order-expand-btn">
+            {% if page.preorder %}
+              Forudbestil fra Mærkelex
+            {% else %}
+              Køb fra Mærkelex
+            {% endif %}
+          </a>
         </div>
         <form method="post" action="{{ site.paymentsSiteUrl }}" id="order-form" class="hidden-order">
           <span class="collapse-purchase">&lsaquo;</span>
-          <h2>Køb {{page.name}} mærke</h2>
+          <h2>{% if page.preorder %}Forudbestil{% else %}Køb{% endif %} {{ page.name }} mærke</h2>
           <input type="hidden" name="return-url" value="http://xn--mrkelex-mxa.dk{{ page.url }}" id="return-url">
           <input type="hidden" name="badge" value="{{ page.id | remove_first: "/m/" }}">
           <div class="order-part">
@@ -169,6 +175,13 @@ layout: default
               Vi leverer i hele landet, men desværre ikke internationalt.
               <a href="mailto:kontakt@maerkelex.dk">Kontakt os</a> for en særlig aftale, hvis du ønsker international levering.
           </p>
+          {% if page.preorder %}
+            <p>
+              Du foretager en forudbestilling.
+              Det betyder at pengene trækkes med det sammen, og mærket samt kvittering for køb sendes så snart lager haves.
+              Der kan gå op til et par måneder fra din bestilling til du modtager mærkerne, alt efter hvor lang tid det tager at få mærket produceret.
+            </p>
+          {% endif %}
           <button class="btn buylink">Bestil mærke</button>
         </form>
       </div>

--- a/_m/36-timer.html
+++ b/_m/36-timer.html
@@ -16,4 +16,6 @@ tags:
 age: 12+
 image: 36-timer.jpg
 buylink: https://www.facebook.com/36timer
+price: 20
+preorder: true
 ---

--- a/index.html
+++ b/index.html
@@ -17,7 +17,11 @@ title: Søg efter spejdermærker
         {% assign m_highlight_class = m.highlight %}
         {% if m.price != null %}
           {% assign m_purchasable = "purchasable" %}
-          {% assign m_highlight_text = "<strong>Køb for " | append: m.price | append: " kr</strong>" %}
+          {% if m.preorder %}
+            {% assign m_highlight_text = "<strong>Forudbestil</strong>" %}
+          {% else %}
+            {% assign m_highlight_text = "<strong>Køb for " | append: m.price | append: " kr</strong>" %}
+          {% endif %}
         {% elsif m_highlight_class == "popular" %}
           {% assign m_highlight_text = "Mest populære!" %}
         {% elsif m_highlight_class == "new" %}

--- a/js/raw-search.js
+++ b/js/raw-search.js
@@ -119,7 +119,7 @@ function renderResults(matches) {
         {% assign m_image = "' + match.image + '" %}
         {% assign m_name = "' + match.name + '" %}
         {% assign m_highlight_class = "' + (match.highlight || '') + '" %}
-        {% assign m_highlight_text = "' + (match.price ? '<strong>Køb for ' + match.price + ' kr</strong>' : match.highlight == 'popular' ? 'Mest populære!' : match.highlight == 'new' ? 'Nyhed!' : 'Læs mere') + '" %}
+        {% assign m_highlight_text = "' + (match.price ? (match.preorder ? '<strong>Forudbestil</strong>' : '<strong>Køb for ' + match.price + ' kr</strong>') : match.highlight == 'popular' ? 'Mest populære!' : match.highlight == 'new' ? 'Nyhed!' : 'Læs mere') + '" %}
         {% assign m_purchasable = "' + (match.price ? 'purchasable' : '') + '" %}
         {% capture maerke_result %}'{% include maerkebox.html %}';{% endcapture %}
         return {{ maerke_result | strip_newlines }}

--- a/m.json
+++ b/m.json
@@ -17,7 +17,8 @@
       "url": {{ m.url | jsonify }},
       "highlight": {% if m.highlight %}"{{ m.highlight }}"{% else %}null{% endif %},
       "price": {% if m.price %}{{ m.price }}{% else %}null{% endif %},
-      "shippingPrice": {% if m.shippingprice %}{{ m.shippingprice }}{% else %}null{% endif %}
+      "shippingPrice": {% if m.shippingprice %}{{ m.shippingprice }}{% else %}null{% endif %},
+      "preorder": {% if m.preorder %}true{% else %}false{% endif %}
     }{% unless forloop.last %},{% endunless %}{% endfor %}
   ],
   "defaultShippingPrice": {{ site.defaultShippingPrice }}

--- a/m.summary.json
+++ b/m.summary.json
@@ -1,4 +1,4 @@
 ---
 ---
 {% assign sorted_m = site.m | sort: "name" %}
-{ "m": [{% for m in sorted_m %} { "name": {{ m.name | jsonify }}, "image": {{ m.image | jsonify }}, "tags": [{% for tag in m.tags %} "{{ tag }}"{% unless forloop.last %},{% endunless %}{% endfor %}], "age": {% if m.age %}"{{ m.age }}"{% else %}"*"{% endif %}, "url": {{ m.url | jsonify }}, "highlight": {% if m.highlight %}"{{ m.highlight }}"{% else %}null{% endif %},"price": {% if m.price %}{{ m.price }}{% else %}null{% endif %} }{% unless forloop.last %},{% endunless %}{% endfor %} ] }
+{ "m": [{% for m in sorted_m %} { "name": {{ m.name | jsonify }}, "image": {{ m.image | jsonify }}, "tags": [{% for tag in m.tags %} "{{ tag }}"{% unless forloop.last %},{% endunless %}{% endfor %}], "age": {% if m.age %}"{{ m.age }}"{% else %}"*"{% endif %}, "url": {{ m.url | jsonify }}, "highlight": {% if m.highlight %}"{{ m.highlight }}"{% else %}null{% endif %},"price": {% if m.price %}{{ m.price }}{% else %}null{% endif %},"preorder": {% if m.preorder %}true{% else %}false{% endif %} }{% unless forloop.last %},{% endunless %}{% endfor %} ] }

--- a/shop.html
+++ b/shop.html
@@ -2,7 +2,7 @@
 layout: default-no-container
 title: Køb mærker
 ---
-<div class="container">
+<div class="container align-center">
     <div class="content">
         <div class="align-center">
             <h1>Shop</h1>
@@ -22,15 +22,11 @@ title: Køb mærker
                 {% assign m_name = m.name %}
                 {% assign m_purchasable = "" %}
                 {% assign m_highlight_class = m.highlight %}
-                {% if m.price != null %}
                 {% assign m_purchasable = "purchasable" %}
-                {% assign m_highlight_text = "<strong>Køb for " | append: m.price | append: " kr</strong>" %}
-                {% elsif m_highlight_class == "popular" %}
-                {% assign m_highlight_text = "Mest populære!" %}
-                {% elsif m_highlight_class == "new" %}
-                {% assign m_highlight_text = "Nyhed!" %}
+                {% if m.preorder %}
+                    {% assign m_highlight_text = "<strong>Forudbestil</strong>" %}
                 {% else %}
-                {% assign m_highlight_text = false %}
+                    {% assign m_highlight_text = "<strong>Køb for " | append: m.price | append: " kr</strong>" %}
                 {% endif %}
                 {% include maerkebox.html %}
             {% endif %}


### PR DESCRIPTION
Add preorder flag, which puts a badge with a price in preorder mode

These badges can be bought as usual, but will not be shipped until they have been produced.

Also set `price: 20` and `preorder: true` for the 36-timer badge in preparation for getting to sell it!

![image](https://user-images.githubusercontent.com/859106/36845748-2f168828-1d58-11e8-9d0a-6fcc742dff5a.png)

![image](https://user-images.githubusercontent.com/859106/36845757-355a2ca8-1d58-11e8-922b-e9db4019f2f9.png)

![image](https://user-images.githubusercontent.com/859106/36845761-39550274-1d58-11e8-8d17-f9709a21ab41.png)

![image](https://user-images.githubusercontent.com/859106/36845763-3c5f387c-1d58-11e8-94f2-b74fe01546a4.png)
