### PR TITLE
Set preorder on spejd365

### DIFF
--- a/_includes/orderForm.html
+++ b/_includes/orderForm.html
@@ -3,8 +3,7 @@
   <input type="hidden" name="return-url" value="http://xn--mrkelex-mxa.dk{{ page.url }}" id="return-url" />
   <input type="hidden" name="badge" value="{{ page.id | remove_first: "/m/" }}"> {% if page.preorder %}
   <div class="preorder-part">
-    Denne bestilling er en forudbestilling. Det betyder at vi køber mærker ind baseret på hvor mange mærker der
-    bestilles. Vi har altså ikke mærkerne på lager, og der kan gå op til 4 måneder med levering, afhængig af vores
+    Denne bestilling er en forudbestilling. Vi har altså ikke mærkerne på lager, og der kan gå op til 7 uger før mærkerne er fremme, afhængig af vores
     leverandørs produktionstid.
     <br /><br />
     Ved forudbestillinger hæver vi pengene når du gennemfører købet, da det fungerer som en produktion til bestilling.

--- a/_m/spejd365.md
+++ b/_m/spejd365.md
@@ -9,6 +9,7 @@ age: 6+
 image: spejd365.jpg
 price: 20
 highlight: popular
+preorder: true
 ---
 For at tage Spejd365 skal spejderen gå med spejdertørklæde i et år.
 


### PR DESCRIPTION
Set preorder while we wait for new badges to be delivered. Hopefully this avoids a massive amount of emails from customers, and is more transparent when they order.