### PR TITLE
Remove restriction on postal code

### DIFF
--- a/kurv.html
+++ b/kurv.html
@@ -183,7 +183,7 @@ title: Indkøbskurv
           </div>
         </form>
       </div>
-    </section>      
+    </section>
   </div>
 </div>
 
@@ -280,8 +280,6 @@ title: Indkøbskurv
 
       if (!obj.postalCode) {
         errors[prefix + "-postal-code"] = "Mangler postnr";
-      } else if (obj.postalCode.length !== 4) {
-        errors[prefix + "-postal-code"] = "Postnummer har forkert længde";
       }
 
       if (!obj.city) {


### PR DESCRIPTION
Some countries have postal codes that are longer than 4 characters.

Remove valiation of postal code: It can now be valid with less or more characters than 4.