### PR TITLE
Updated shipping prices to match the vat changes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,9 +28,9 @@ defaults:
 
 future: true
 
-paymentsSiteUrl: "https://salg.mærkelex.dk"
-defaultShippingPrice: 25
-internationalShippingPrice: 50
+paymentsSiteUrl: "http://localhost:4004/"
+defaultShippingPrice: 35
+internationalShippingPrice: 55
 
 shippingCountries:
 - Danmark


### PR DESCRIPTION
new laws went in effect back in january making it so there is also vat paid on shipping. To keep the same profit we had before we need to raise the shipping price.